### PR TITLE
Enforcing unit movement range

### DIFF
--- a/models/unit.js
+++ b/models/unit.js
@@ -7,6 +7,7 @@ class Unit{
     this.infantryDefense = infantryDefense;
     this.unitType = unitType;
     this.movementRange = movementRange;
+    this.rangeCounter = 0;
     this.size = size;
     this.tile = tile;
     this.player = player;
@@ -17,11 +18,13 @@ class Unit{
       tile.add(this)
       this.tile.remove(this)
       this.tile = tile
+      this.rangeCounter++
     }
   }
 
   _canMoveTo(tile){
-    return Math.abs(this.tile.x - tile.x + this.tile.y - tile.y) <= 1
+    return (Math.abs(this.tile.x - tile.x + this.tile.y - tile.y) <= 1) &&
+      (this.rangeCounter < this.movementRange)
   }
 
   attack(unit){

--- a/models/unit.js
+++ b/models/unit.js
@@ -1,3 +1,4 @@
+var UNIT_RANGE_COUNTER_RESET = 0;
 class Unit{
   constructor(name, vehicleAttack, infantryAttack, vehicleDefense, infantryDefense, unitType, movementRange, size = 1, tile, player){
     this.name = name;
@@ -7,7 +8,7 @@ class Unit{
     this.infantryDefense = infantryDefense;
     this.unitType = unitType;
     this.movementRange = movementRange;
-    this.rangeCounter = 0;
+    this.rangeCounter = UNIT_RANGE_COUNTER_RESET;
     this.size = size;
     this.tile = tile;
     this.player = player;
@@ -46,5 +47,9 @@ class Unit{
   die(){
     this.tile.remove(this);
     this.player.remove(this);
+  }
+
+  resetRangeCounter(){
+    this.rangeCounter = UNIT_RANGE_COUNTER_RESET
   }
 }

--- a/spec/unitSpec.js
+++ b/spec/unitSpec.js
@@ -13,9 +13,9 @@ beforeEach(function(){
   fakeTile2.y = -1
   fakeTile3 = new Mocktile()
   fakeTile3.x = 1
-  fakeTile3.y = 1 
+  fakeTile3.y = 1
   var fakePlayer = []
-  test_soldier = new Unit('soldier', 1, 2, 1, 2, 'infantry', 3, 1, fakeTile, fakePlayer)
+  test_soldier = new Unit('soldier', 1, 2, 1, 2, 'infantry', 2, 1, fakeTile, fakePlayer)
   test_tank = new Unit('tank', 2, 2, 1, 2, 'vehicle', 4, 3, 'n/a', 'n/a')
   fakeTile.add(test_soldier)
   fakePlayer.add(test_soldier)
@@ -33,16 +33,22 @@ describe("Unit#moveTo",[
   it("should add the unit to the new tile",[
     test_soldier.moveTo(fakeTile2),
     expect(fakeTile2.units).toContain(test_soldier)
-    ]),
+  ]),
   it("should remove it from the old tile",[
-    test_soldier.moveTo(fakeTile2), 
+    test_soldier.moveTo(fakeTile2),
     dont(expect(fakeTile.units).toContain(test_soldier))
-    ]),
+  ]),
   it("shouldn't be able to move to tiles that are not adjacent",[
     test_soldier.moveTo(fakeTile3),
     dont(expect(fakeTile3.units).toContain(test_soldier))
-    ])
+  ]),
+  it("should not move unit if that would exceed unit movement range", [
+    test_soldier.moveTo(fakeTile2),
+    test_soldier.moveTo(fakeTile),
+    test_soldier.moveTo(fakeTile2),
+    expect(fakeTile.units).toContain(test_soldier)
   ])
+])
 
 describe("Unit#attack", [
   it("returns the unit's vehicle attack when attacking a vehicle",[

--- a/spec/unitSpec.js
+++ b/spec/unitSpec.js
@@ -47,6 +47,10 @@ describe("Unit#moveTo",[
     test_soldier.moveTo(fakeTile),
     test_soldier.moveTo(fakeTile2),
     expect(fakeTile.units).toContain(test_soldier)
+  ]),
+  it("successful moves increment rangeCounter by 1",[
+    test_soldier.moveTo(fakeTile2),
+    expect(test_soldier.rangeCounter).toEqual(1)
   ])
 ])
 

--- a/spec/unitSpec.js
+++ b/spec/unitSpec.js
@@ -75,3 +75,11 @@ describe("Unit#die", [
     expect(fakeTile.units.length).toEqual(0)
   ])
 ])
+
+describe("Unit#resetRangeCounter", [
+  it("unit range counter can be reset", [
+    test_soldier.moveTo(fakeTile2),
+    test_soldier.resetRangeCounter(),
+    expect(test_soldier.rangeCounter).toEqual(0)
+  ])
+])


### PR DESCRIPTION
As title says...
I've used a counter to determine when movement range has been reached - this comes with a resetting method which will probably need to be called on all unit at the start of each turn.